### PR TITLE
readme: remove 'autre'

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,3 @@ Cette section est dédiée au support 64 bit pour l'architecture x86.
 
 ### ARM
 Cette section est dédiée à tout ce qui touche à l'architecture ARM (vide pour l'instant).
-
-### Autres
-Cette section est dédiée à tout ce qui ne rentre pas en rapport avec les architectures x86 et x64, les systèmes de fichiers, les ports COM, les drivers et tout le reste.


### PR DESCRIPTION
Since there is no "autre" folder (outside of x86_64/) and COM port are in fact related to x86_64

Maybe can be added in future about e.g. ext2fs but for now it's make no sense

(sorry i forgot to do it in previous pr)
